### PR TITLE
Make cp be able to copy files to directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 Cargo.lock
+.idea

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -42,11 +42,11 @@ pub fn cp(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
 }
 fn _cp(src: &Path, dst: &Path) -> Result<()> {
     let _guard = gsl::read();
-    let mut dst = dst;
     let mut _tmp;
+    let mut dst = dst;
     if dst.is_dir() {
-        if let Some(trunk) = src.file_name() {
-            _tmp = dst.join(trunk);
+        if let Some(file_name) = src.file_name() {
+            _tmp = dst.join(file_name);
             dst = &_tmp;
         }
     }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -42,6 +42,14 @@ pub fn cp(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
 }
 fn _cp(src: &Path, dst: &Path) -> Result<()> {
     let _guard = gsl::read();
+    let mut dst = dst;
+    let mut _tmp;
+    if dst.is_dir() {
+        if let Some(trunk) = src.file_name() {
+            _tmp = dst.join(trunk);
+            dst = &_tmp;
+        }
+    }
     with_path(src, std::fs::copy(src, dst)).map(|_size| ())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,12 +41,8 @@
 //!
 //! ```
 //! # use xshell::cmd;
-//! if cfg!(target_os = "macos") {
-//!     let output = cmd!("date").read()?;
-//! } else {
-//!     let output = cmd!("date --iso").read()?;
-//!     assert!(output.chars().all(|c| "01234567890-".contains(c)));
-//! }
+//! let output = cmd!("date --iso").read()?;
+//! assert!(output.chars().all(|c| "01234567890-".contains(c)));
 //! # Ok::<(), xshell::Error>(())
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,12 @@
 //!
 //! ```
 //! # use xshell::cmd;
-//! let output = cmd!("date --iso").read()?;
-//! assert!(output.chars().all(|c| "01234567890-".contains(c)));
+//! if cfg!(target_os = "macos") {
+//!     let output = cmd!("date").read()?;
+//! } else {
+//!     let output = cmd!("date --iso").read()?;
+//!     assert!(output.chars().all(|c| "01234567890-".contains(c)));
+//! }
 //! # Ok::<(), xshell::Error>(())
 //! ```
 //!


### PR DESCRIPTION
This PR makes the cp command be able to copy files to a directory, similar to what bash supports: 
This doesn't yield huge productivity, but it saves a few keystrokes and makes the behaviour closer to that of a shell. 
It also temporary "fixes" a test which was failing on MacOs since it doesn't support `date --iso`.
```rust
// currently 
let src = "/some/file.txt";
cp(src, Path::new("./directory").join(src));
// with this PR
cp(src, "./directory");
```