### PR TITLE
Add mktemp_d

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.exclude": {
+    "target": true
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "files.exclude": {
-    "target": true
+    "**/target": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.8
+
+- Add option to not echo command at all
+- Add option to censor command contents when echoing
+
 ## 0.1.6
 
 - `.read()` chomps `\r\n` on Windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.9
+
+- `mktemp_d` creates an (insecure, world readable) temporary directory.
+- `cp(foo, bar)` copies `foo` _into_ `bar`, if `bar` is an existing directory.
+
 ## 0.1.8
 
 - Add option to not echo command at all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,18 @@
 ## 0.1.9
 
 - `mktemp_d` creates an (insecure, world readable) temporary directory.
-- `cp(foo, bar)` copies `foo` _into_ `bar`, if `bar` is an existing directory.
+- Fix cp docs
 
 ## 0.1.8
 
 - Add option to not echo command at all
 - Add option to censor command contents when echoing
+- Add docs
+
+## 0.1.7
+
+- `cp(foo, bar)` copies `foo` _into_ `bar`, if `bar` is an existing directory.
+- Tweak reading API
 
 ## 0.1.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xshell"
 description = "Utilities for quick shell scripting in Rust"
 categories = ["development-tools::build-utils", "filesystem"]
-version = "0.1.8"
+version = "0.1.9"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/xshell"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
@@ -13,4 +13,4 @@ exclude = [".github/", "bors.toml", "rustfmt.toml", "cbench", "mock_bin/"]
 [workspace]
 
 [dependencies]
-xshell-macros = { version = "=0.1.8", path = "./xshell-macros"}
+xshell-macros = { version = "=0.1.9", path = "./xshell-macros" }

--- a/cbench/baseline/src/main.rs
+++ b/cbench/baseline/src/main.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 fn main() {
     let mut cmd = Command::new("date");
-    cmd.arg("--iso");
+    cmd.arg("+%Y-%m-%d");
     let output = cmd.output().unwrap();
     if !output.status.success() {
         panic!("command `{:?}` failed: {}", cmd, output.status);

--- a/cbench/ducted/src/main.rs
+++ b/cbench/ducted/src/main.rs
@@ -1,6 +1,6 @@
 use duct::cmd;
 
 fn main() {
-    let date = cmd!("date", "--iso").read().unwrap();
+    let date = cmd!("date", "+%Y-%m-%d").read().unwrap();
     print!("today is: {}\n", date)
 }

--- a/cbench/xshelled/src/main.rs
+++ b/cbench/xshelled/src/main.rs
@@ -1,6 +1,6 @@
 use xshell::cmd;
 
 fn main() {
-    let date = cmd!("date --iso").read().unwrap();
+    let date = cmd!("date +%Y-%m-%d").read().unwrap();
     print!("today is: {}\n", date)
 }

--- a/mock_bin/date.rs
+++ b/mock_bin/date.rs
@@ -9,7 +9,7 @@ fn main() {
 
 fn try_main() -> io::Result<()> {
     let args = std::env::args().collect::<Vec<_>>();
-    if args != ["date", "--iso"] {
+    if args != ["date", "+%Y-%m-%d"] {
         return Err(io::Error::new(io::ErrorKind::Other, "invalid args"));
     }
     println!("1982-06-25");

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -46,9 +46,14 @@ fn _mkdir_p(path: &Path) -> Result<()> {
     with_path(path, std::fs::create_dir_all(path))
 }
 
-/// Copies the file at `src` into the file at `dst`.
+/// Copies `src` into `dst`.
 ///
-/// `dst` must be the path to a file. It will be created if it does not exist.
+/// `src` must be a file, but `dst` need not be. If `dst` is an existing
+/// directory, `src` will be copied into a file in the `dst` directory whose
+/// name is same as that of `src`.
+///
+/// Otherwise, `dst` is a file or does not exist, and `src` will be copied into
+/// it.
 pub fn cp(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
     _cp(src.as_ref(), dst.as_ref())
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use crate::{error::fs_err, gsl, Result};
 
@@ -86,6 +89,30 @@ pub fn cwd() -> Result<PathBuf> {
     with_path(&Path::new("."), std::env::current_dir())
 }
 
+/// Creates an empty, world-readable, temporary directory.
+///
+/// Returns a [`TempDir`] value that provides the path of this temporary
+/// directory. When dropped, the temporary directory and all of its contents
+/// will be removed.
+pub fn mktemp_d() -> Result<TempDir> {
+    let _guard = gsl::read();
+    let base = std::env::temp_dir();
+    mkdir_p(&base)?;
+
+    static CNT: AtomicUsize = AtomicUsize::new(0);
+
+    let mut n_try = 0u32;
+    loop {
+        let cnt = CNT.fetch_add(1, Ordering::Relaxed);
+        let path = base.join(format!("xshell-tmp-dir-{}", cnt));
+        match std::fs::create_dir(&path) {
+            Ok(()) => return Ok(TempDir { path }),
+            Err(io_err) if n_try == 1024 => return Err(fs_err(path, io_err)),
+            Err(_) => n_try += 1,
+        }
+    }
+}
+
 fn with_path<T>(path: &Path, res: Result<T, std::io::Error>) -> Result<T> {
     res.map_err(|io_err| fs_err(path.to_path_buf(), io_err))
 }
@@ -114,4 +141,23 @@ fn read_dir_aux(path: &Path) -> std::io::Result<Vec<PathBuf>> {
     }
     res.sort();
     Ok(res)
+}
+
+/// A temporary directory.
+#[derive(Debug)]
+pub struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    /// Returns the path of this temporary directory.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        rm_rf(&self.path).unwrap()
+    }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -158,6 +158,6 @@ impl TempDir {
 
 impl Drop for TempDir {
     fn drop(&mut self) {
-        rm_rf(&self.path).unwrap()
+        let _ = rm_rf(&self.path);
     }
 }

--- a/src/gsl.rs
+++ b/src/gsl.rs
@@ -143,6 +143,12 @@ fn read_write_read() {
 }
 
 #[test]
+fn write_read_same_thread() {
+    let _w = write();
+    let _r = read();
+}
+
+#[test]
 #[should_panic(
     expected = "calling write() with an active read guard on the same thread would deadlock"
 )]

--- a/src/gsl.rs
+++ b/src/gsl.rs
@@ -112,7 +112,7 @@ impl Drop for Guard {
             }),
             Some(Repr::Write(_)) => CACHE.with(|it| {
                 assert_eq!(it.get(), Cache::Write);
-                it.set(Cache::Read(0))
+                it.set(Cache::Read(0));
             }),
             None => {}
         }
@@ -143,7 +143,7 @@ fn read_write_read() {
 }
 
 #[test]
-fn write_read_same_thread() {
+fn write_read() {
     let _w = write();
     let _r = read();
 }
@@ -152,7 +152,7 @@ fn write_read_same_thread() {
 #[should_panic(
     expected = "calling write() with an active read guard on the same thread would deadlock"
 )]
-fn read_write_same_thread() {
+fn read_write() {
     let _r = read();
     let _w = write();
 }

--- a/src/gsl.rs
+++ b/src/gsl.rs
@@ -1,4 +1,5 @@
-//! Global shell lock
+//! Global shell lock.
+
 use std::{
     cell::Cell,
     mem::MaybeUninit,
@@ -25,7 +26,7 @@ pub(crate) fn write() -> Guard {
     // this thread has no writers. if it has readers, this will deadlock.
     let w_guard = static_rw_lock().write().unwrap_or_else(|err| err.into_inner());
     // if we got to here, we must not have any readers.
-    assert!(matches!(CACHE.with(Cell::get), Cache::Read(0)));
+    assert_eq!(CACHE.with(Cell::get), Cache::Read(0));
     // note that we have a writer.
     CACHE.with(|it| it.set(Cache::Write));
     Guard(Some(Repr::Write(w_guard)))
@@ -67,7 +68,7 @@ fn static_rw_lock() -> &'static RwLock<()> {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Cache {
     Read(usize),
     Write,

--- a/src/gsl.rs
+++ b/src/gsl.rs
@@ -92,3 +92,26 @@ impl Drop for Guard {
         }
     }
 }
+
+#[test]
+fn read_write_read() {
+    eprintln!("get r1");
+    let r1 = read();
+    eprintln!("got r1");
+    let h = std::thread::spawn(|| {
+        eprintln!("get w1");
+        let w1 = write();
+        eprintln!("got w1");
+        drop(w1);
+        eprintln!("gave w1");
+    });
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    eprintln!("get r2");
+    let r2 = read();
+    eprintln!("got r2");
+    drop(r1);
+    eprintln!("gave r1");
+    drop(r2);
+    eprintln!("gave r2");
+    h.join().unwrap();
+}

--- a/src/gsl.rs
+++ b/src/gsl.rs
@@ -8,9 +8,9 @@ use std::{
     sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-/// If, on the same thread, there are multiple calls to `read` or `write`, then
-/// the `Guard`s returned should be dropped in the reverse order that they were
-/// acquired.
+/// If, on the same thread, there are multiple calls to [`read`] or [`write`],
+/// then the `Guard`s returned should be dropped in the reverse order that they
+/// were acquired.
 ///
 /// If this is violated, e.g. in
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@
 //!
 //! # Implementation details
 //!
-//! The design is heavily inspired by the Juila language:
+//! The design is heavily inspired by the Julia language:
 //!
 //! * [Shelling Out Sucks](https://julialang.org/blog/2012/03/shelling-out-sucks/)
 //! * [Put This In Your Pipe](https://julialang.org/blog/2013/04/put-this-in-your-pipe/)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,7 +261,7 @@ pub use xshell_macros::__cmd;
 pub use crate::{
     env::{pushd, pushenv, Pushd, Pushenv},
     error::{Error, Result},
-    fs::{cp, cwd, mkdir_p, read_dir, read_file, rm_rf, write_file},
+    fs::{cp, cwd, mkdir_p, mktemp_d, read_dir, read_file, rm_rf, write_file, TempDir},
 };
 
 /// Constructs a [`Cmd`] from the given string.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! ```
 //! # use xshell::cmd;
-//! let output = cmd!("date --iso").read()?;
+//! let output = cmd!("date +%Y-%m-%d").read()?;
 //! assert!(output.chars().all(|c| "01234567890-".contains(c)));
 //! # Ok::<(), xshell::Error>(())
 //! ```
@@ -190,7 +190,7 @@
 //!
 //! The `cmd!` macro uses a simple proc-macro internally. It doesn't depend on
 //! helper libraries, so the fixed-cost impact on compile times is moderate.
-//! Compiling a trivial program with `cmd!("date --iso")` takes one second.
+//! Compiling a trivial program with `cmd!("date +%Y-%m-%d")` takes one second.
 //! Equivalent program using only `std::process::Command` compiles in 0.25
 //! seconds.
 //!

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -1,6 +1,6 @@
 use std::{ffi::OsStr, thread, time::Duration, time::Instant};
 
-use xshell::{cmd, cwd, mkdir_p, pushd, pushenv, read_file, rm_rf, write_file};
+use xshell::{cmd, cp, cwd, mkdir_p, mktemp_d, pushd, pushenv, read_file, rm_rf, write_file};
 
 #[test]
 fn smoke() {
@@ -206,6 +206,28 @@ fn test_pushenv_lock() {
 
     t1.join().unwrap();
     t2.join().unwrap();
+}
+
+#[test]
+fn test_cp() {
+    let path;
+    {
+        let tempdir = mktemp_d().unwrap();
+        path = tempdir.path().to_path_buf();
+        let foo = tempdir.path().join("foo.txt");
+        let bar = tempdir.path().join("bar.txt");
+        let dir = tempdir.path().join("dir");
+        write_file(&foo, "hello world").unwrap();
+        mkdir_p(&dir).unwrap();
+
+        cp(&foo, &bar).unwrap();
+        assert_eq!(read_file(&bar).unwrap(), "hello world");
+
+        cp(&foo, &dir).unwrap();
+        assert_eq!(read_file(&dir.join("foo.txt")).unwrap(), "hello world");
+        assert!(path.exists());
+    }
+    assert!(!path.exists());
 }
 
 fn check_failure(code: &str, err_msg: &str) {

--- a/xshell-macros/Cargo.toml
+++ b/xshell-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xshell-macros"
 description = "Private implementation detail of xshell crate"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- Use POSIX date invocations, don't use `--iso` option
  - This might have been part of what was making tests fail on macOS
  - I ran `cargo t` on my macOS machine and tests failed because macOS's default `date` doesn't have the `--iso` option
- Add changelog entry for 0.1.7, 0.1.8 retroactively
- Fix cp doc
  - It acts like shell's `cp` when `dst` is a directory
- Allow acquiring many read locks on the same thread
  - Update the thread-local cache to track readers as well as the writer
- Doc and test internal `gsl` more, note some caveats
- Add `mktemp_d`, doc it
- Update version and release notes
- Ignore `target` files in vscode

Closes #12 , can also probably close #7 after this.