### PR TITLE
Add a `current_dir` function to Cmd

### DIFF
--- a/tests/it.rs
+++ b/tests/it.rs
@@ -154,6 +154,24 @@ fn pushd_parent_dir() {
 }
 
 #[test]
+fn cmd_current_dir() {
+    let tempdir = mktemp_d().unwrap();
+    let path = tempdir.path().to_path_buf();
+    let filename = "example.txt";
+    let file = path.join(filename);
+    let contents = "test 123";
+    write_file(&file, contents).unwrap();
+
+    // Kind of cludgey, but windows uses `type` not `cat` to print a file to stdout.
+    let read_contents =
+        if cfg!(windows) { cmd!("type {filename}") } else { cmd!("cat {filename}") }
+            .current_dir(path)
+            .read()
+            .unwrap();
+    assert_eq!(contents, read_contents);
+}
+
+#[test]
 fn test_pushd_lock() {
     let t1 = thread::spawn(|| {
         let _p = pushd("cbench").unwrap();


### PR DESCRIPTION
This avoids the need to either grab the `Command` directly, or to use a small-scoped `pushd`.

# Downsides

The main reason not to provide this is that there's an edge case where it behaves in a platform specific manner: If the path to the program is relative (e.g. `cmd!("./foo")` or something) and `current_dir` is used, windows and unix will resolve different paths for the executable to run.

For example, `cmd!("./bar.ext").current_dir("somewhere")` will:

- run `somewhere/bar.ext` on unix (e.g. the directory change happens before resolving the path to the executable)
- run `./bar.ext` on windows (the directory change happens after)

## Possible options

1. Don't expose this function. I think this doesn't actually help anything, since users will just extract the `Command` when they want to use an api not on `Cmd`, and hit this problem on it. (Also, it's just annoying to work around these sorts of issues, and makes `Cmd` not feel like its pulling its weight as a `Command` wrapper)

2. Ignore the problem. That's what this patch does, which might be fine given `xshell`'s nature as a minimal wrapper rather than something fully featured, especially given that this kind of usage is rather rare in practice.

3. Follow std::process::Command's lead and be platform specific, but document it (possibly by just linking to it's docs).

4. Normalize the behavior. This is a bit finnicky but mostly doable if we standardize on window's behavior (which IMO is more consistent, and fits with the argument order of std::process::Command). This probably looks something like:

    ```rust
    fn _current_dir(&mut self, dir: &Path) -> Result<()> {
        // Call `canonicalize` on the program path if it's relative, as suggested by the
        // https://doc.rust-lang.org/std/process/struct.Command.html#method.current_dir
        // documentation:
        let program: &Path = self.args[0].as_ref();

        // `Path::is_relative()` will return true for cases like `program == "git"`,
        // so check if it has path separators. Also, `_lossy` is fine here since it
        // can never produce a path separator that didn't already exist.
        let is_relative =
            program.is_relative() && program.to_string_lossy().chars().any(std::path::is_separator);

        if is_relative {
            let _guard = gsl::read();
            let canonical = std::fs::canonicalize(program)?;
            self.args[0] = canonical.into();
        }
        self.dir = Some(dir.into());
        Ok(())
    }
    ```

    The downsides here are:
    1. Difficulty testing. (The test I added was hard to write portably as-is (Edit: and I didn't succeed!), and this becomes much harder)
    2. Surprising behavior for users porting unix-only `std::process::Command` code to `xshell`.
    3. `fs::canonicalize` is fallible, and so this impacts the API.

LMK what you prefer.