### PR TITLE
Add mkdir to write_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.11
+
+- `write_file` now creates the intervening directory path if it doesn't exit
+
 ## 0.1.10
 
 - `echo_cmd` output goes to stderr, not stdout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xshell"
 description = "Utilities for quick shell scripting in Rust"
 categories = ["development-tools::build-utils", "filesystem"]
-version = "0.1.10"
+version = "0.1.11"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/xshell"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
@@ -13,4 +13,4 @@ exclude = [".github/", "bors.toml", "rustfmt.toml", "cbench", "mock_bin/"]
 [workspace]
 
 [dependencies]
-xshell-macros = { version = "=0.1.10", path = "./xshell-macros" }
+xshell-macros = { version = "=0.1.11", path = "./xshell-macros" }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -28,8 +28,8 @@ fn _read_file(path: &Path) -> Result<String> {
     with_path(path, std::fs::read_to_string(path))
 }
 
-/// Writes the `contents` into the file at `path`, creating the file if it
-/// didn't exist already.
+/// Writes the `contents` into the file at `path`, creating the file (and the
+/// path to it) if it didn't exist already.
 pub fn write_file(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<()> {
     _write_file(path.as_ref(), contents.as_ref())
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -34,6 +34,9 @@ pub fn write_file(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<
     _write_file(path.as_ref(), contents.as_ref())
 }
 fn _write_file(path: &Path, contents: &[u8]) -> Result<()> {
+    if let Some(p) = path.parent() {
+        mkdir_p(p)?;
+    }
     let _guard = gsl::read();
     with_path(path, std::fs::write(path, contents))
 }

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -273,6 +273,14 @@ pub fn f() {{
 }
 
 #[test]
+fn write_makes_directory() {
+    let tempdir = mktemp_d().unwrap();
+    let folder = tempdir.path().join("some/nested/folder/structure");
+    write_file(folder.join(".gitinclude"), "").unwrap();
+    assert!(folder.exists());
+}
+
+#[test]
 fn test_compile_failures() {
     check_failure("cmd!(92)", "expected a plain string literal");
     check_failure(r#"cmd!(r"raw")"#, "expected a plain string literal");

--- a/xshell-macros/Cargo.toml
+++ b/xshell-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xshell-macros"
 description = "Private implementation detail of xshell crate"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This makes the "creating the file if it doesn't exist" stronger, as it does not fail with a missing directory.

I don't know if this matches the behavior of any shell more or less than the existing implementation, but it matches my intuition for a simple "write a file, creating it if it doesn't exist" better than failing to create the file if the folder doesn't exist.

Alternative implementation:

```rust
let _guard = gsl::read();
if let Some(p) = path.parent() {
    with_path(path, std::fs::create_dir_all(p))?;
}
with_path(path, std::fs::write(path, contents))
```