### PR TITLE
fix escaped quoation mark not handled properly

### DIFF
--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -475,7 +475,7 @@ fn string_escapes() {
     setup();
 
     assert_eq!(cmd!("\"hello\"").to_string(), "\"hello\"");
-    assert_eq!(cmd!("\"\"\" asdf\" \"").to_string(), "\"\"\" asdf\" \"");
+    assert_eq!(cmd!("\"\"\"asdf\"\"\"").to_string(), r##""""asdf""""##);
     assert_eq!(cmd!("\\\\\\\\\\\\\\\\\\\\\\\\\\").to_string(), "\\\\\\\\\\\\\\\\\\\\\\\\\\");
 }
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -470,6 +470,16 @@ fn formatting() {
     cmd!("cargo fmt --all -- --check").run().unwrap()
 }
 
+#[test]
+#[allow(unused_must_use)]
+fn string_escapes() {
+    setup();
+
+    cmd!("\"hello\"");
+    cmd!("\"\"\" asdf\" \"");
+    cmd!("\\\\\\\\\\\\\\\\\\\\\\\\\\");
+}
+
 fn sleep_ms(ms: u64) {
     thread::sleep(std::time::Duration::from_millis(ms))
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -471,13 +471,12 @@ fn formatting() {
 }
 
 #[test]
-#[allow(unused_must_use)]
 fn string_escapes() {
     setup();
 
-    cmd!("\"hello\"");
-    cmd!("\"\"\" asdf\" \"");
-    cmd!("\\\\\\\\\\\\\\\\\\\\\\\\\\");
+    assert_eq!(cmd!("\"hello\"").to_string(), "\"hello\"");
+    assert_eq!(cmd!("\"\"\" asdf\" \"").to_string(), "\"\"\" asdf\" \"");
+    assert_eq!(cmd!("\\\\\\\\\\\\\\\\\\\\\\\\\\").to_string(), "\\\\\\\\\\\\\\\\\\\\\\\\\\");
 }
 
 fn sleep_ms(ms: u64) {

--- a/xshell-macros/src/lib.rs
+++ b/xshell-macros/src/lib.rs
@@ -184,10 +184,6 @@ fn parse_ts(s: &str) -> TokenStream {
     s.parse().unwrap()
 }
 
-fn lit_ts(s: &str) -> TokenStream {
-    TokenTree::Literal(proc_macro::Literal::string(s)).into()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/xshell-macros/src/lib.rs
+++ b/xshell-macros/src/lib.rs
@@ -134,13 +134,13 @@ fn tokenize(cmd: &str) -> impl Iterator<Item = Result<Token<'_>>> + '_ {
     })
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 struct Token<'a> {
     joined_to_prev: bool,
     text: &'a str,
     kind: TokenKind,
 }
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 enum TokenKind {
     Word,
     String,
@@ -182,18 +182,4 @@ fn respan(ts: TokenStream, span: Span) -> TokenStream {
 
 fn parse_ts(s: &str) -> TokenStream {
     s.parse().unwrap()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use TokenKind::*;
-
-    #[test]
-    fn double_quoted() {
-        let res = tokenize(r#"""asdf"""#).collect::<Result<Vec<Token<'_>>>>().unwrap();
-        eprintln!("res = {:?}", res);
-
-        assert_eq!(&*res, [Token { joined_to_prev: true, text: "\"asdf\"", kind: Word }])
-    }
 }


### PR DESCRIPTION
fix #23.

This is because we were using `trim_matches`, which will trim repeatedly. This means that if we have a string `"ls \"asdf\""` is will trim 1 `"` at the beginning but *2* `"` at the end. Thus, the trimmed string will become `ls \"asdf\` which is unable to be parsed.