### PR TITLE
Fix GSL with many readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.15
+
+- Correctly handle multiple internal read guards.
 
 ## 0.1.14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xshell"
 description = "Utilities for quick shell scripting in Rust"
 categories = ["development-tools::build-utils", "filesystem"]
-version = "0.1.14" # Update two other places as well.
+version = "0.1.15" # also update xshell-macros/Cargo.toml and CHANGELOG.md
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/xshell"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
@@ -13,4 +13,4 @@ exclude = [".github/", "bors.toml", "rustfmt.toml", "cbench", "mock_bin/"]
 [workspace]
 
 [dependencies]
-xshell-macros = { version = "=0.1.14", path = "./xshell-macros" }
+xshell-macros = { version = "=0.1.15", path = "./xshell-macros" }

--- a/src/gsl.rs
+++ b/src/gsl.rs
@@ -28,24 +28,34 @@ pub(crate) struct Guard(Option<Repr>);
 
 #[derive(Debug)]
 enum Repr {
-    Read(RwLockReadGuard<'static, ()>),
+    Read(Option<RwLockReadGuard<'static, ()>>),
     Write(RwLockWriteGuard<'static, ()>),
+}
+
+thread_local! {
+    static CACHE: Cell<Cache> = Cell::new(Cache::Read(0));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Cache {
+    Read(usize),
+    Write,
 }
 
 /// Returns a [`Guard`] for write access to global resources.
 pub(crate) fn write() -> Guard {
     match CACHE.with(Cell::get) {
         Cache::Write => {
-            // this thread (and only this thread) can already write. don't try to
-            // acquire another write guard.
+            // this thread (and only this thread) can already write. don't try
+            // to acquire another write guard.
             Guard(None)
         }
         Cache::Read(readers) => {
             assert_eq!(
                 readers, 0,
-                "calling write() with an active read guard on the same thread would deadlock"
+                "calling write() with an active read guard on the same thread might deadlock"
             );
-            let w_guard = static_rw_lock().write().unwrap_or_else(|err| err.into_inner());
+            let w_guard = static_rw_lock().write().unwrap();
             // note that we have a writer.
             CACHE.with(|it| it.set(Cache::Write));
             Guard(Some(Repr::Write(w_guard)))
@@ -67,15 +77,15 @@ pub(crate) fn read() -> Guard {
             if readers == 0 {
                 // this thread has no readers or writers. try to acquire the
                 // lock for reading.
-                let r_guard = static_rw_lock().read().unwrap_or_else(|err| err.into_inner());
+                let r_guard = static_rw_lock().read().unwrap();
                 // note that we now have 1 reader.
                 CACHE.with(|it| it.set(Cache::Read(1)));
-                Guard(Some(Repr::Read(r_guard)))
+                Guard(Some(Repr::Read(Some(r_guard))))
             } else {
                 // this thread can already read. don't try to acquire another
                 // read guard. also, note that we have another reader.
                 CACHE.with(|it| it.set(Cache::Read(readers + 1)));
-                Guard(None)
+                Guard(Some(Repr::Read(None)))
             }
         }
     }
@@ -90,25 +100,20 @@ fn static_rw_lock() -> &'static RwLock<()> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Cache {
-    Read(usize),
-    Write,
-}
-
-thread_local! {
-    static CACHE: Cell<Cache> = Cell::new(Cache::Read(0));
-}
-
 impl Drop for Guard {
     fn drop(&mut self) {
         match self.0 {
-            Some(Repr::Read(_)) => CACHE.with(|it| {
-                let n = match it.get() {
+            Some(Repr::Read(ref r_guard)) => CACHE.with(|it| {
+                let readers = match it.get() {
                     Cache::Read(n) => n,
                     Cache::Write => unreachable!("had both a reader and a writer"),
                 };
-                it.set(Cache::Read(n - 1));
+                assert_eq!(
+                    r_guard.is_some(),
+                    readers == 1,
+                    "read guards dropped in the wrong order"
+                );
+                it.set(Cache::Read(readers - 1));
             }),
             Some(Repr::Write(_)) => CACHE.with(|it| {
                 assert_eq!(it.get(), Cache::Write);
@@ -121,25 +126,16 @@ impl Drop for Guard {
 
 #[test]
 fn read_write_read() {
-    eprintln!("get r1");
     let r1 = read();
-    eprintln!("got r1");
-    let h = std::thread::spawn(|| {
-        eprintln!("get w1");
+    let handle = std::thread::spawn(|| {
         let w1 = write();
-        eprintln!("got w1");
         drop(w1);
-        eprintln!("gave w1");
     });
     std::thread::sleep(std::time::Duration::from_millis(300));
-    eprintln!("get r2");
     let r2 = read();
-    eprintln!("got r2");
-    drop(r1);
-    eprintln!("gave r1");
     drop(r2);
-    eprintln!("gave r2");
-    h.join().unwrap();
+    drop(r1);
+    handle.join().unwrap();
 }
 
 #[test]
@@ -150,9 +146,27 @@ fn write_read() {
 
 #[test]
 #[should_panic(
-    expected = "calling write() with an active read guard on the same thread would deadlock"
+    expected = "calling write() with an active read guard on the same thread might deadlock"
 )]
 fn read_write() {
     let _r = read();
     let _w = write();
+}
+
+#[test]
+fn read_drop_write() {
+    let r1 = read();
+    drop(r1);
+    let w1 = write();
+    drop(w1);
+}
+
+#[test]
+fn read_2_drop_write() {
+    let r1 = read();
+    let r2 = read();
+    drop(r2);
+    drop(r1);
+    let w1 = write();
+    drop(w1);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,7 @@
 //! ```
 //! # use xshell::cmd;
 //! let err = cmd!("false").read().unwrap_err();
-//! assert_eq!(
-//!     err.to_string(),
-//!     "command `false` failed, exit code: 1",
-//! );
+//! assert!(err.to_string().starts_with("command `false` failed"));
 //! ```
 //!
 //! <hr>

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -479,6 +479,24 @@ fn string_escapes() {
     assert_eq!(cmd!("\\\\").to_string(), r#"\\"#);
 }
 
+#[test]
+fn cd_tempdir() {
+    println!("cwd: {}", cwd().unwrap().display());
+    let tmp = mktemp_d().unwrap();
+    println!("tmp: {}", tmp.path().display());
+    // Enter directory in child block so pushd guard is dropped before tmp
+    {
+        let _cwd = pushd(tmp.path()).unwrap();
+        println!("cwd: {}", cwd().unwrap().display());
+    }
+}
+
+#[test]
+fn cd_tempdir_no_block() {
+    let tmp = mktemp_d().unwrap();
+    let _cwd = pushd(tmp.path()).unwrap();
+}
+
 fn sleep_ms(ms: u64) {
     thread::sleep(std::time::Duration::from_millis(ms))
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -96,7 +96,7 @@ fn exit_status() {
     setup();
 
     let err = cmd!("false").read().unwrap_err();
-    assert_eq!(err.to_string(), "command `false` failed, exit code: 1");
+    assert!(err.to_string().starts_with("command `false` failed"));
 }
 
 #[test]

--- a/xshell-macros/Cargo.toml
+++ b/xshell-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xshell-macros"
 description = "Private implementation detail of xshell crate"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Close #35.

The issue there was that we weren't correctly decrementing the number of readers in the `CACHE` when dropping a second read guard.

I added some new tests, including the failing example in the issue (now passes).

Also includes other misc fixes.