### PR TITLE
re-enable signal tests on macos

### DIFF
--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -144,7 +144,7 @@ fn exit_status() {
 }
 
 #[test]
-#[cfg_attr(not(target_os = "linux"), ignore)]
+#[cfg_attr(not(unix), ignore)]
 fn exit_status_signal() {
     let sh = setup();
 
@@ -169,7 +169,7 @@ fn ignore_status_no_such_command() {
 }
 
 #[test]
-#[cfg_attr(not(target_os = "linux"), ignore)]
+#[cfg_attr(not(unix), ignore)]
 fn ignore_status_signal() {
     let sh = setup();
 


### PR DESCRIPTION
bors r+