### PR TITLE
docs: Link to sh-inline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,12 +235,15 @@
 //! [`duct`] is a crate for heavy-duty process herding, with support for
 //! pipelines.
 //!
+//! [`sh-inline`] is a crate that depends on bash, but handles shell quoting correctly.
+//!
 //! Most of what this crate provides can be open-coded using
 //! [`std::process::Command`] and [`std::fs`]. If you only need to spawn a
 //! single process, using `std` is probably better (but don't forget to check
 //! the exit status!).
 //!
 //! [`duct`]: https://github.com/oconnor663/duct.rs
+//! [`sh-inline`]: https://docs.rs/sh-inline/latest/sh_inline
 //! [shell injection]:
 //!     https://en.wikipedia.org/wiki/Code_injection#Shell_injection
 //!


### PR DESCRIPTION
Now that xshell does not have process-global state, I am considering
switching to it.
But some people may actually want to use bash (e.g. some of my scripts
have bash conditionals).  Also, sh-inline has optional integration with
cap-std which I am using today.  So just in the interest of linking
to related crates, let's add this one.

I added the reverse link here: https://github.com/cgwalters/rust-sh-inline/pull/6