### PR TITLE
Emit more informative error message when cwd does not exist

### DIFF
--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -460,3 +460,14 @@ fn string_escapes() {
     assert_eq!(cmd!(sh, "\"\"\"asdf\"\"\"").to_string(), r##""""asdf""""##);
     assert_eq!(cmd!(sh, "\\\\").to_string(), r#"\\"#);
 }
+
+#[test]
+fn nonexistent_current_directory() {
+    let sh = setup();
+    sh.change_dir("nonexistent");
+    let err = cmd!(sh, "ls").run().unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "failed to get current directory: No such file or directory (os error 2)"
+    );
+}


### PR DESCRIPTION
Fixes #72 in the manner described in https://github.com/matklad/xshell/issues/72#issuecomment-1627735581.

Nits are welcome.