### PR TITLE
Return the environment variables currently known to shell

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -667,7 +667,10 @@ impl Shell {
     ///
     /// The returned hash map contains a snapshot of the process’s environment variables at the time of this invocation. Modifications to environment variables afterwards will not be reflected in the returned iterator.
     pub fn vars_os(&self) -> Vec<(OsString, OsString)> {
-        Vec::from_iter(self.env.borrow().iter().map(|(k, v)| (k.to_owned(), v.to_owned())))
+        let mut vars =
+            Vec::from_iter(self.env.borrow().iter().map(|(k, v)| (k.to_owned(), v.to_owned())));
+        vars.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
+        vars
     }
 
     /// Returns the environment variables set for this shell.
@@ -682,12 +685,14 @@ impl Shell {
     /// the environment is not valid unicode. If this is not desired, consider
     /// using [`Shell::vars_os`](Self::vars_os).
     pub fn vars(&self) -> Vec<(String, String)> {
-        Vec::from_iter(
+        let mut vars = Vec::from_iter(
             self.env
                 .borrow()
                 .iter()
                 .map(|(k, v)| (k.to_str().unwrap().to_string(), v.to_str().unwrap().to_string())),
-        )
+        );
+        vars.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
+        vars
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,9 +681,9 @@ impl Shell {
     ///
     /// # Panics
     ///
-    /// While iterating, the returned iterator will panic if any key or value in
-    /// the environment is not valid unicode. If this is not desired, consider
-    /// using [`Shell::vars_os`](Self::vars_os).
+    /// Will panic if any key or value in the environment is not valid unicode.
+    /// If this is not desired, consider using
+    /// [`Shell::vars_os`](Self::vars_os).
     pub fn vars(&self) -> Vec<(String, String)> {
         let mut vars = Vec::from_iter(
             self.env

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -685,14 +685,15 @@ impl Shell {
     /// If this is not desired, consider using
     /// [`Shell::vars_os`](Self::vars_os).
     pub fn vars(&self) -> Vec<(String, String)> {
-        let mut vars = Vec::from_iter(
-            self.env
-                .borrow()
-                .iter()
-                .map(|(k, v)| (k.to_str().unwrap().to_string(), v.to_str().unwrap().to_string())),
-        );
-        vars.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
-        vars
+        #[inline]
+        fn os_str_to_string(os_str: OsString) -> String {
+            os_str.to_str().unwrap().to_string()
+        }
+        // re-use functionality from `Self::vars_os` to reduce code repetition
+        self.vars_os()
+            .into_iter()
+            .map(|(k, v)| (os_str_to_string(k), os_str_to_string(v)))
+            .collect()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,6 +662,33 @@ impl Shell {
         let cd = self.cwd.borrow();
         cd.join(p)
     }
+
+    /// Returns the environment variables set for this shell.
+    ///
+    /// The returned hash map contains a snapshot of the process’s environment variables at the time of this invocation. Modifications to environment variables afterwards will not be reflected in the returned iterator.
+    pub fn vars_os(&self) -> Vec<(OsString, OsString)> {
+        Vec::from_iter(self.env.borrow().iter().map(|(k, v)| (k.to_owned(), v.to_owned())))
+    }
+
+    /// Returns the environment variables set for this shell.
+    ///
+    /// The returned hash map contains a snapshot of the process’s environment
+    /// variables at the time of this invocation. Modifications to environment
+    /// variables afterwards will not be reflected in the returned iterator.
+    ///
+    /// # Panics
+    ///
+    /// While iterating, the returned iterator will panic if any key or value in
+    /// the environment is not valid unicode. If this is not desired, consider
+    /// using [`Shell::vars_os`](Self::vars_os).
+    pub fn vars(&self) -> Vec<(String, String)> {
+        Vec::from_iter(
+            self.env
+                .borrow()
+                .iter()
+                .map(|(k, v)| (k.to_str().unwrap().to_string(), v.to_str().unwrap().to_string())),
+        )
+    }
 }
 
 /// RAII guard returned from [`Shell::push_dir`].


### PR DESCRIPTION
Addresses #77 

TO DETERMINE:

- [ ] is it really necessary to have both `vars` and `vars_os`?
- [x] what should the return type of `vars`/`vars_os` be? For now, I defaulted to a "minimal iterable which does not retain references to the actual data" (a `Vec`) ([resolved](https://github.com/matklad/xshell/pull/78#issuecomment-1881071175)) 