### PR TITLE
Add `Cmd::before_spawn` to allow modifying the resulting `std::process::Command` before spawning it

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,7 @@ enum ErrorKind {
     CmdIo { err: io::Error, cmd: CmdData },
     CmdUtf8 { err: FromUtf8Error, cmd: CmdData },
     CmdStdin { err: io::Error, cmd: CmdData },
+    BeforeSpawnIo { err: io::Error, cmd: CmdData },
 }
 
 impl From<ErrorKind> for Error {
@@ -103,6 +104,9 @@ impl fmt::Display for Error {
             ErrorKind::CmdStdin { err, cmd } => {
                 write!(f, "failed to write to stdin of command `{cmd}`: {err}")
             }
+            ErrorKind::BeforeSpawnIo { err, cmd } => {
+                write!(f, "io error when running before_spawn function on command `{cmd}`: {err}")
+            }
         }?;
         Ok(())
     }
@@ -171,6 +175,11 @@ impl Error {
     pub(crate) fn new_cmd_stdin(cmd: &Cmd<'_>, err: io::Error) -> Error {
         let cmd = cmd.data.clone();
         ErrorKind::CmdStdin { err, cmd }.into()
+    }
+
+    pub(crate) fn new_before_spawn_io(cmd: &Cmd<'_>, err: io::Error) -> Error {
+        let cmd = cmd.data.clone();
+        ErrorKind::BeforeSpawnIo { err, cmd }.into()
     }
 }
 


### PR DESCRIPTION
Hey! I've been using this crate a bunch and it's been great!

For one of my use cases I need to run a process under a different uid. If I want to do this I can use xshell to build the command then I need to eject out and convert it directly to `std::process::Command` to set the uid. If I do that, though, I can no longer use `read` and I end up needing to write a bunch of code to replicate it.

Adding a `uid` method felt too platform-specific so this PR instead adds a `before_spawn` method that registers a function that gets called with the `std::process::Command` just before it is spawned. It is based on the [`before_spawn`][0] method in duct which does the exact same thing.

### Notes
- `CmdData` needs to be `Clone + Send + Sync` and `Box<dyn Fn(&mut Command)>` is none of those so I ended having to place the list of methods directly in `Cmd`.
- I started off trying to bound the functions by `'a` but that broke one of the tests so I've left the hook as `Box<dyn Fn(&mut Command) + 'static>` instead.
- Hook functions don't get run when converting `Cmd` to `std::process::Command` since they are fallible. I have documented this in the method documentation.

[0]: https://docs.rs/duct/latest/duct/struct.Expression.html#method.before_spawn