### PR TITLE
Implement Clone to Shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.6
+
+- Implement `Clone` for `Shell`.
+
 ## 0.2.5
 
 - Improve error message when a working directory for `cmd!` does not exist.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xshell"
 description = "Utilities for quick shell scripting in Rust"
 categories = ["development-tools::build-utils", "filesystem"]
-version = "0.2.5" # also update xshell-macros/Cargo.toml and CHANGELOG.md
+version = "0.2.6" # also update xshell-macros/Cargo.toml and CHANGELOG.md
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/xshell"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
@@ -14,7 +14,7 @@ exclude = [".github/", "bors.toml", "rustfmt.toml", "cbench", "mock_bin/"]
 [workspace]
 
 [dependencies]
-xshell-macros = { version = "=0.2.5", path = "./xshell-macros" }
+xshell-macros = { version = "=0.2.6", path = "./xshell-macros" }
 
 [dev-dependencies]
 anyhow = "1.0.56"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,7 @@ macro_rules! cmd {
 /// assert_eq!(cwd, process_cwd.join("./target"));
 /// # Ok::<(), xshell::Error>(())
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Shell {
     cwd: RefCell<PathBuf>,
     env: RefCell<HashMap<OsString, OsString>>,

--- a/tests/it/env.rs
+++ b/tests/it/env.rs
@@ -11,29 +11,34 @@ fn test_env() {
     let v1 = "xshell_test_123";
     let v2 = "xshell_test_456";
 
-    assert_env(cmd!(sh, "xecho -$ {v1}").env(v1, "123"), &[(v1, Some("123"))]);
+    let cloned_sh = sh.clone();
 
-    assert_env(
-        cmd!(sh, "xecho -$ {v1} {v2}").envs([(v1, "123"), (v2, "456")].iter().copied()),
-        &[(v1, Some("123")), (v2, Some("456"))],
-    );
-    assert_env(
-        cmd!(sh, "xecho -$ {v1} {v2}")
-            .envs([(v1, "123"), (v2, "456")].iter().copied())
-            .env_remove(v2),
-        &[(v1, Some("123")), (v2, None)],
-    );
-    assert_env(
-        cmd!(sh, "xecho -$ {v1} {v2}")
-            .envs([(v1, "123"), (v2, "456")].iter().copied())
-            .env_remove("nothing"),
-        &[(v1, Some("123")), (v2, Some("456"))],
-    );
+    for sh in [&sh, &cloned_sh] {
+        assert_env(cmd!(sh, "xecho -$ {v1}").env(v1, "123"), &[(v1, Some("123"))]);
+
+        assert_env(
+            cmd!(sh, "xecho -$ {v1} {v2}").envs([(v1, "123"), (v2, "456")].iter().copied()),
+            &[(v1, Some("123")), (v2, Some("456"))],
+        );
+        assert_env(
+            cmd!(sh, "xecho -$ {v1} {v2}")
+                .envs([(v1, "123"), (v2, "456")].iter().copied())
+                .env_remove(v2),
+            &[(v1, Some("123")), (v2, None)],
+        );
+        assert_env(
+            cmd!(sh, "xecho -$ {v1} {v2}")
+                .envs([(v1, "123"), (v2, "456")].iter().copied())
+                .env_remove("nothing"),
+            &[(v1, Some("123")), (v2, Some("456"))],
+        );
+    }
 
     let _g1 = sh.push_env(v1, "foobar");
     let _g2 = sh.push_env(v2, "quark");
 
     assert_env(cmd!(sh, "xecho -$ {v1} {v2}"), &[(v1, Some("foobar")), (v2, Some("quark"))]);
+    assert_env(cmd!(cloned_sh, "xecho -$ {v1} {v2}"), &[(v1, None), (v2, None)]);
 
     assert_env(
         cmd!(sh, "xecho -$ {v1} {v2}").env(v1, "wombo"),

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -312,6 +312,18 @@ fn test_push_env() {
 }
 
 #[test]
+fn test_push_env_clone() {
+    let sh = setup();
+
+    assert!(sh.var_os(VAR).is_none());
+    let guard = sh.push_env(VAR, "1");
+    let cloned = sh.clone();
+    drop(guard);
+    assert_eq!(sh.var_os(VAR), None);
+    assert_eq!(cloned.var_os(VAR), Some("1".into()));
+}
+
+#[test]
 fn test_push_env_and_set_var() {
     let sh = setup();
 

--- a/tests/it/tidy.rs
+++ b/tests/it/tidy.rs
@@ -12,8 +12,6 @@ fn versions_match() {
     };
 
     let v1 = read_version("./Cargo.toml");
-    let v2 = read_version("./xshell-macros/Cargo.toml");
-    assert_eq!(v1, v2);
 
     let cargo_toml = sh.read_file("./Cargo.toml").unwrap();
     let dep = format!("xshell-macros = {{ version = \"={}\",", v1);

--- a/xshell-macros/Cargo.toml
+++ b/xshell-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xshell-macros"
 description = "Private implementation detail of xshell crate"
-version = "0.2.5"
+version = "0.2.6"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/xshell"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]


### PR DESCRIPTION
This allows you to clone the shell so you can create a "sub-shell", with different environments and reuse it 
(that way you "inherit" the shell and modify it for your needs,)
`push_env` almost does that, except across function returns where it's hard to keep the guards around and sometimes you need to "reset" those envs because you want to execute something else in the meantime and then go back to that other "environment"

(imagine making a shell for the project, then preparing android by changing the cwd and env vars, afterward, there are other preparations for other targets, and then when it comes to building it needs to rebuild all these environments,  unless it created a subshell and stored it)


Solves https://github.com/matklad/xshell/issues/79