### PR TITLE
Add an ability to read exit code and specific streams

### DIFF
--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -55,6 +55,21 @@ fn multiline() {
 }
 
 #[test]
+fn read_with_exit_status() {
+    let sh = setup();
+    let output = cmd!(
+        sh,
+        "
+        xecho hello
+        "
+    )
+    .read_stdout_output()
+    .unwrap();
+    assert_eq!(output.stream_output, "hello");
+    assert!(output.exit_status.success());
+}
+
+#[test]
 fn interpolation() {
     let sh = setup();
 
@@ -183,6 +198,15 @@ fn read_stderr() {
 
     let output = cmd!(sh, "xecho -f -e snafu").ignore_status().read_stderr().unwrap();
     assert!(output.contains("snafu"));
+}
+
+#[test]
+fn read_stderr_with_exit_code() {
+    let sh = setup();
+
+    let output = cmd!(sh, "xecho -f -e snafu").ignore_status().read_stderr_output().unwrap();
+    assert!(output.stream_output.contains("snafu"));
+    assert!(!output.exit_status.success())
 }
 
 #[test]


### PR DESCRIPTION
## Description
This PR enhances the functionality of the crate by adding the ability to read both the necessary stream and the exit code of a process.

## Motivation
First, I want to commend you on creating such a fantastic crate. It has significantly streamlined my work with processes, saving me a lot of time and effort. 

The current implementation assumes that the presence of stderr indicates a non-zero exit code, which is not always accurate. In my application, this distinction is crucial because I need to print stdout directly while only reading stderr. Additionally, not having direct access to the exit status forces me to parse stderr for all possible scenarios, making the process error-prone and inefficient.

Check status doesn't fulfill my needs, because I'm either getting the exit status or stderr. And I'd like to have both 

## Changes
Added functionality to read the exit code of a process altogether with the specified stream.
