### PR TITLE
Add `_timeout` methods for cmd to execute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = [".github/", "bors.toml", "rustfmt.toml", "cbench", "mock_bin/"]
 [workspace]
 
 [dependencies]
+process_control = "4.0.3"
 xshell-macros = { version = "=0.2.6", path = "./xshell-macros" }
 
 [dev-dependencies]

--- a/examples/timeout.rs
+++ b/examples/timeout.rs
@@ -5,28 +5,28 @@ use xshell::{cmd, Shell};
 
 fn main() -> Result<()> {
     let sh = Shell::new()?;
-    let command = cmd!(sh, "sleep 5");
+    let command = cmd!(sh, "sleep 5").timeout(Duration::from_secs(3));
 
     // Run the command with a timeout
-    match command.run_timeout(Duration::from_secs(3)) {
+    match command.run() {
         Ok(_) => println!("Command completed successfully."),
         Err(e) => eprintln!("Command failed: {}", e),
     }
 
     // Run the command with a timeout and get stdout
-    match command.read_timeout(Duration::from_secs(3)) {
+    match command.read() {
         Ok(output) => println!("Command output: {}", output),
         Err(e) => eprintln!("Command failed: {}", e),
     }
 
     // Run the command with a timeout and get stderr
-    match command.read_stderr_timeout(Duration::from_secs(3)) {
+    match command.read_stderr() {
         Ok(output) => println!("Command stderr: {}", output),
         Err(e) => eprintln!("Command failed: {}", e),
     }
 
     // Run the command with a timeout and get the full output
-    match command.output_timeout(Duration::from_secs(3)) {
+    match command.output() {
         Ok(output) => println!("Command completed successfully.{output:?}"),
         Err(e) => eprintln!("Command failed: {}", e),
     }

--- a/examples/timeout.rs
+++ b/examples/timeout.rs
@@ -1,0 +1,35 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use xshell::{cmd, Shell};
+
+fn main() -> Result<()> {
+    let sh = Shell::new()?;
+    let command = cmd!(sh, "sleep 5");
+
+    // Run the command with a timeout
+    match command.run_timeout(Duration::from_secs(3)) {
+        Ok(_) => println!("Command completed successfully."),
+        Err(e) => eprintln!("Command failed: {}", e),
+    }
+
+    // Run the command with a timeout and get stdout
+    match command.read_timeout(Duration::from_secs(3)) {
+        Ok(output) => println!("Command output: {}", output),
+        Err(e) => eprintln!("Command failed: {}", e),
+    }
+
+    // Run the command with a timeout and get stderr
+    match command.read_stderr_timeout(Duration::from_secs(3)) {
+        Ok(output) => println!("Command stderr: {}", output),
+        Err(e) => eprintln!("Command failed: {}", e),
+    }
+
+    // Run the command with a timeout and get the full output
+    match command.output_timeout(Duration::from_secs(3)) {
+        Ok(output) => println!("Command completed successfully.{output:?}"),
+        Err(e) => eprintln!("Command failed: {}", e),
+    }
+
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,7 @@ enum ErrorKind {
     CmdIo { err: io::Error, cmd: CmdData },
     CmdUtf8 { err: FromUtf8Error, cmd: CmdData },
     CmdStdin { err: io::Error, cmd: CmdData },
-    CmdTimeout { err: RecvTimeoutError, cmd: CmdData },
+    CmdTimeout { err: io::Error, cmd: CmdData },
 }
 
 impl From<ErrorKind> for Error {
@@ -180,7 +180,7 @@ impl Error {
         ErrorKind::CmdStdin { err, cmd }.into()
     }
 
-    pub(crate) fn new_timeout(cmd: &Cmd<'_>, err: RecvTimeoutError) -> Error {
+    pub(crate) fn new_timeout(cmd: &Cmd<'_>, err: io::Error) -> Error {
         let cmd = cmd.data.clone();
         ErrorKind::CmdTimeout { err, cmd }.into()
     }

--- a/tests/data/xsleep.rs
+++ b/tests/data/xsleep.rs
@@ -1,0 +1,59 @@
+use std::io::{self, Write};
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    if let Err(err) = try_main() {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
+}
+
+fn try_main() -> io::Result<()> {
+    let mut sleep_seconds = 0;
+    let mut fail = false;
+    let mut suicide = false;
+
+    let mut args = std::env::args().skip(1).peekable();
+    while let Some(arg) = args.peek() {
+        match arg.as_str() {
+            "-f" => fail = true,
+            "-s" => suicide = true,
+            _ => break,
+        }
+        args.next();
+    }
+
+    if let Some(arg) = args.next() {
+        sleep_seconds = arg.parse().unwrap_or_else(|_| {
+            eprintln!("error: invalid number of seconds");
+            std::process::exit(1);
+        });
+    }
+
+    thread::sleep(Duration::from_secs(sleep_seconds));
+
+    if fail {
+        return Err(io::ErrorKind::Other.into());
+    }
+    if suicide {
+        #[cfg(unix)]
+        unsafe {
+            let pid = signals::getpid();
+            if pid > 0 {
+                signals::kill(pid, 9);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+mod signals {
+    use std::os::raw::c_int;
+    extern "C" {
+        pub fn kill(pid: c_int, sig: c_int) -> c_int;
+        pub fn getpid() -> c_int;
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -12,13 +12,18 @@ fn setup() -> Shell {
 
     let sh = Shell::new().unwrap();
     let xecho_src = sh.current_dir().join("./tests/data/xecho.rs");
+    let xsleep_src = sh.current_dir().join("./tests/data/xsleep.rs");
     let target_dir = sh.current_dir().join("./target/");
 
     ONCE.call_once(|| {
         cmd!(sh, "rustc {xecho_src} --out-dir {target_dir}")
             .quiet()
             .run()
-            .unwrap_or_else(|err| panic!("failed to install binaries from mock_bin: {}", err))
+            .unwrap_or_else(|err| panic!("failed to install binaries from mock_bin: {}", err));
+        cmd!(sh, "rustc {xsleep_src} --out-dir {target_dir}")
+            .quiet()
+            .run()
+            .unwrap_or_else(|err| panic!("failed to install binaries from mock_bin: {}", err));
     });
 
     sh.set_var("PATH", target_dir);

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,6 +1,7 @@
 mod tidy;
 mod env;
 mod compile_failures;
+mod timeout;
 
 use std::{ffi::OsStr, path::Path};
 

--- a/tests/it/timeout.rs
+++ b/tests/it/timeout.rs
@@ -1,0 +1,87 @@
+use std::time::Duration;
+
+use xshell::{cmd, Shell};
+
+#[test]
+fn test_run_timeout_success() {
+    let sh = Shell::new().unwrap();
+    let command = cmd!(sh, "sleep 1"); // Command that sleeps for 1 second
+
+    // Run the command with a timeout of 3 seconds
+    let result = command.run_timeout(Duration::from_secs(3));
+    assert!(result.is_ok(), "Command should complete successfully within the timeout");
+}
+
+#[test]
+fn test_run_timeout_failure() {
+    let sh = Shell::new().unwrap();
+    let command = cmd!(sh, "sleep 5"); // Command that sleeps for 5 seconds
+
+    // Run the command with a timeout of 3 seconds
+    let result = command.run_timeout(Duration::from_secs(3));
+    assert!(result.is_err(), "Command should fail due to timeout");
+}
+
+#[test]
+fn test_read_timeout_success() {
+    let sh = Shell::new().unwrap();
+    let command = cmd!(sh, "echo Hello, world!"); // Command that prints a message
+
+    // Run the command with a timeout of 3 seconds and read stdout
+    let result = command.read_timeout(Duration::from_secs(3));
+    assert!(result.is_ok(), "Command should complete successfully within the timeout");
+    assert_eq!(result.unwrap(), "Hello, world!");
+}
+
+#[test]
+fn test_read_timeout_failure() {
+    let sh = Shell::new().unwrap();
+    let command = cmd!(sh, "sleep 5"); // Command that sleeps for 5 seconds
+
+    // Run the command with a timeout of 3 seconds and read stdout
+    let result = command.read_timeout(Duration::from_secs(3));
+    assert!(result.is_err(), "Command should fail due to timeout");
+}
+
+#[test]
+fn test_read_stderr_timeout_success() {
+    let sh = Shell::new().unwrap();
+    let command = cmd!(sh, "sh -c 'echo Error message 1>&2'"); // Command that prints an error message to stderr
+
+    // Run the command with a timeout of 3 seconds and read stderr
+    let result = command.read_stderr_timeout(Duration::from_secs(3));
+    assert!(result.is_ok(), "Command should complete successfully within the timeout");
+    assert_eq!(result.unwrap(), "Error message");
+}
+
+#[test]
+fn test_read_stderr_timeout_failure() {
+    let sh = Shell::new().unwrap();
+    let command = cmd!(sh, "sleep 5"); // Command that sleeps for 5 seconds
+
+    // Run the command with a timeout of 3 seconds and read stderr
+    let result = command.read_stderr_timeout(Duration::from_secs(3));
+    assert!(result.is_err(), "Command should fail due to timeout");
+}
+
+#[test]
+fn test_output_timeout_success() {
+    let sh = Shell::new().unwrap();
+    let command = cmd!(sh, "echo Hello, world!"); // Command that prints a message
+
+    // Run the command with a timeout of 3 seconds and get the full output
+    let result = command.output_timeout(Duration::from_secs(3));
+    assert!(result.is_ok(), "Command should complete successfully within the timeout");
+    let output = result.unwrap();
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "Hello, world!");
+}
+
+#[test]
+fn test_output_timeout_failure() {
+    let sh = Shell::new().unwrap();
+    let command = cmd!(sh, "sleep 5"); // Command that sleeps for 5 seconds
+
+    // Run the command with a timeout of 3 seconds and get the full output
+    let result = command.output_timeout(Duration::from_secs(3));
+    assert!(result.is_err(), "Command should fail due to timeout");
+}

--- a/tests/it/timeout.rs
+++ b/tests/it/timeout.rs
@@ -1,76 +1,77 @@
+use crate::setup;
 use std::time::Duration;
 
-use xshell::{cmd, Shell};
+use xshell::cmd;
 
 #[test]
 fn test_run_timeout_success() {
-    let sh = Shell::new().unwrap();
-    let command = cmd!(sh, "sleep 1"); // Command that sleeps for 1 second
+    let sh = setup();
+    let command = cmd!(sh, "xsleep 1"); // Command that xsleeps for 1 second
 
     // Run the command with a timeout of 3 seconds
-    let result = command.run_timeout(Duration::from_secs(3));
+    let result = command.timeout(Duration::from_secs(3)).run();
     assert!(result.is_ok(), "Command should complete successfully within the timeout");
 }
 
 #[test]
 fn test_run_timeout_failure() {
-    let sh = Shell::new().unwrap();
-    let command = cmd!(sh, "sleep 5"); // Command that sleeps for 5 seconds
+    let sh = setup();
+    let command = cmd!(sh, "xsleep 5"); // Command that xsleeps for 5 seconds
 
     // Run the command with a timeout of 3 seconds
-    let result = command.run_timeout(Duration::from_secs(3));
+    let result = command.timeout(Duration::from_secs(3)).run();
     assert!(result.is_err(), "Command should fail due to timeout");
 }
 
 #[test]
 fn test_read_timeout_success() {
-    let sh = Shell::new().unwrap();
+    let sh = setup();
     let command = cmd!(sh, "echo Hello, world!"); // Command that prints a message
 
     // Run the command with a timeout of 3 seconds and read stdout
-    let result = command.read_timeout(Duration::from_secs(3));
+    let result = command.timeout(Duration::from_secs(3)).read();
     assert!(result.is_ok(), "Command should complete successfully within the timeout");
     assert_eq!(result.unwrap(), "Hello, world!");
 }
 
 #[test]
 fn test_read_timeout_failure() {
-    let sh = Shell::new().unwrap();
-    let command = cmd!(sh, "sleep 5"); // Command that sleeps for 5 seconds
+    let sh = setup();
+    let command = cmd!(sh, "xsleep 5"); // Command that xsleeps for 5 seconds
 
     // Run the command with a timeout of 3 seconds and read stdout
-    let result = command.read_timeout(Duration::from_secs(3));
+    let result = command.timeout(Duration::from_secs(3)).read();
     assert!(result.is_err(), "Command should fail due to timeout");
 }
 
 #[test]
 fn test_read_stderr_timeout_success() {
-    let sh = Shell::new().unwrap();
+    let sh = setup();
     let command = cmd!(sh, "sh -c 'echo Error message 1>&2'"); // Command that prints an error message to stderr
 
     // Run the command with a timeout of 3 seconds and read stderr
-    let result = command.read_stderr_timeout(Duration::from_secs(3));
+    let result = command.timeout(Duration::from_secs(3)).read_stderr();
     assert!(result.is_ok(), "Command should complete successfully within the timeout");
     assert_eq!(result.unwrap(), "Error message");
 }
 
 #[test]
 fn test_read_stderr_timeout_failure() {
-    let sh = Shell::new().unwrap();
-    let command = cmd!(sh, "sleep 5"); // Command that sleeps for 5 seconds
+    let sh = setup();
+    let command = cmd!(sh, "xsleep 5"); // Command that xsleeps for 5 seconds
 
     // Run the command with a timeout of 3 seconds and read stderr
-    let result = command.read_stderr_timeout(Duration::from_secs(3));
+    let result = command.timeout(Duration::from_secs(3)).read_stderr();
     assert!(result.is_err(), "Command should fail due to timeout");
 }
 
 #[test]
 fn test_output_timeout_success() {
-    let sh = Shell::new().unwrap();
+    let sh = setup();
     let command = cmd!(sh, "echo Hello, world!"); // Command that prints a message
 
     // Run the command with a timeout of 3 seconds and get the full output
-    let result = command.output_timeout(Duration::from_secs(3));
+    let result = command.timeout(Duration::from_secs(3)).output();
     assert!(result.is_ok(), "Command should complete successfully within the timeout");
     let output = result.unwrap();
     assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "Hello, world!");
@@ -78,10 +79,10 @@ fn test_output_timeout_success() {
 
 #[test]
 fn test_output_timeout_failure() {
-    let sh = Shell::new().unwrap();
-    let command = cmd!(sh, "sleep 5"); // Command that sleeps for 5 seconds
+    let sh = setup();
+    let command = cmd!(sh, "xsleep 5"); // Command that xsleeps for 5 seconds
 
     // Run the command with a timeout of 3 seconds and get the full output
-    let result = command.output_timeout(Duration::from_secs(3));
+    let result = command.timeout(Duration::from_secs(3)).output();
     assert!(result.is_err(), "Command should fail due to timeout");
 }


### PR DESCRIPTION
Follow suggestion in https://github.com/matklad/xshell/pull/91#issuecomment-2228324022

> At the same time, adding a timeout/deadline method, while preserving blocking API, would be great. I think it's OK to burn a thread just for that:
> 
> - When we spawn a timeout-enabled process, we also spawn a timeout thread which also gets a reference to the Child's handle
> - That thread blocks in https://doc.rust-lang.org/stable/std/sync/mpsc/struct.Receiver.html#method.recv_timeout
> - if timeout elapses, it kills the process, which unblocks the main thread.
> - otherwise, it unblocks when the sender side of the channel is blocked (it's important that we don't leave hanging threads around)

Add timeout relative methods: `run_timeout` / `read_timeout` / `read_stderr_timeout` / `output_timeout`.
