### PR TITLE
Return `ExitStatus` from `Cmd::run`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,11 +959,11 @@ impl<'a> Cmd<'a> {
     /// By default the command itself is echoed to stderr, its standard streams
     /// are inherited, and non-zero return code is considered an error. These
     /// behaviors can be overridden by using various builder methods of the [`Cmd`].
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<ExitStatus> {
         if !self.data.quiet {
             eprintln!("$ {}", self);
         }
-        self.output_impl(false, false).map(|_| ())
+        self.output_impl(false, false).map(|output| output.status)
     }
 
     /// Run the command and return its stdout as a string. Any trailing newline or carriage return will be trimmed.

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -17,7 +17,7 @@ fn setup() -> Shell {
         cmd!(sh, "rustc {xecho_src} --out-dir {target_dir}")
             .quiet()
             .run()
-            .unwrap_or_else(|err| panic!("failed to install binaries from mock_bin: {}", err))
+            .unwrap_or_else(|err| panic!("failed to install binaries from mock_bin: {}", err));
     });
 
     sh.set_var("PATH", target_dir);
@@ -175,6 +175,14 @@ fn ignore_status_signal() {
 
     let output = cmd!(sh, "xecho -s dead").ignore_status().read().unwrap();
     assert_eq!(output, "dead");
+}
+
+#[test]
+fn run_ignore_status_exit_status() {
+    let sh = setup();
+    let status = cmd!(sh, "xecho -f fail").ignore_status().run().unwrap();
+    assert!(!status.success());
+    assert_eq!(status.code(), Some(1));
 }
 
 #[test]

--- a/tests/it/tidy.rs
+++ b/tests/it/tidy.rs
@@ -22,7 +22,7 @@ fn versions_match() {
 fn formatting() {
     let sh = Shell::new().unwrap();
 
-    cmd!(sh, "cargo fmt --all -- --check").run().unwrap()
+    cmd!(sh, "cargo fmt --all -- --check").run().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Implements https://github.com/matklad/xshell/issues/90#issuecomment-2217406011: `Cmd::run` is made to return the `ExitStatus` of the underlying command on `Ok`, allowing access to the exit code on failure if used in conjunction with `ignore_status`. Also adds a test for this behaviour.

Breaking change since `Cmd::run` is public API.