### PR TITLE
Make `Cmd::to_command` public and add docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1048,7 +1048,16 @@ impl<'a> Cmd<'a> {
         Ok(output)
     }
 
-    fn to_command(&self) -> Command {
+    /// Constructs a [`std::process::Command`] for the same command as `self`.
+    ///
+    /// The returned command will invoke the same program from the same working
+    /// directory and with the same environment as `self`.  If the command was
+    /// set to [`ignore_stdout`](Cmd::ignore_stdout) or [`ignore_stderr`](Cmd::ignore_stderr),
+    /// this will apply to the returned command as well.
+    ///
+    /// Other builder methods have no effect on the command returned since they
+    /// control how the command is run, but this method does not yet execute the command.
+    pub fn to_command(&self) -> Command {
         let mut res = Command::new(&self.data.prog);
         res.current_dir(self.shell.current_dir());
         res.args(&self.data.args);

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -36,7 +36,9 @@ fn smoke() {
 #[test]
 fn into_command() {
     let sh = setup();
-    let _: std::process::Command = cmd!(sh, "git branch").into();
+    let cmd = cmd!(sh, "git branch");
+    let _ = cmd.to_command();
+    let _: std::process::Command = cmd.into();
 }
 
 #[test]


### PR DESCRIPTION
This is intended to increase discoverability of the `xshell::Cmd -> std::process::Command` conversion, which is already accessible via a `From` implementation which internally forwards directly to `to_command`, and be able to document which builder methods translate to the new command and which only apply when executing the `xshell` version (e.g., `quiet` obviously doesn't apply, but `ignore_status` and `stdin` also don't, since their effects only happen once the command is invoked).