### PR TITLE
Windows command files support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1050,8 +1050,8 @@ impl Cmd {
     }
 
     #[cfg(not(windows))]
-    fn resolve_program(&self) -> OsString {
-        self.prog.as_os_str().into()
+    fn resolve_program(&self) -> &OsStr {
+        self.prog.as_os_str()
     }
 
     #[cfg(windows)]

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -1,0 +1,37 @@
+#![cfg(windows)]
+
+use xshell::{cmd, Shell};
+
+#[test]
+fn npm() {
+    let sh = Shell::new().unwrap();
+
+    if cmd!(sh, "where npm").read().is_ok() {
+        let script_shell = cmd!(sh, "npm get shell").read().unwrap();
+        assert!(script_shell.ends_with(".exe"));
+
+        let script_shell_explicit = cmd!(sh, "npm.cmd get shell").read().unwrap();
+        assert_eq!(script_shell, script_shell_explicit);
+    }
+}
+
+#[test]
+fn overridden_cmd_path() {
+    let sh = Shell::new().unwrap();
+
+    if cmd!(sh, "where npm").read().is_ok() {
+        // should fail as `PATH` is overridden via Cmd
+        assert!(cmd!(sh, "npm get shell").env("PATH", ".").run().is_err());
+    }
+}
+
+#[test]
+fn overridden_shell_path() {
+    let mut sh = Shell::new().unwrap();
+    sh.set_var("PATH", ".");
+
+    if cmd!(sh, "where npm").read().is_ok() {
+        // should fail as `PATH` is overridden via Shell
+        assert!(cmd!(sh, "npm get shell").env("PATH", ".").run().is_err());
+    }
+}


### PR DESCRIPTION
Fixes #82,

BTW, there are some test failures on Windows (at least on my machine):
```
failures:
    env::test_env_clear
    ignore_status_no_such_command
    unknown_command
```

this MR does not fix them