### PR TITLE
Avoid using non-existant cfg to not trigger lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+## 0.2.7
+
 - MSRV is raised to 1.63.0
+- Avoid using non-existant cfg in macros
 
 ## 0.2.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xshell"
 description = "Utilities for quick shell scripting in Rust"
 categories = ["development-tools::build-utils", "filesystem"]
-version = "0.2.6" # also update xshell-macros/Cargo.toml and CHANGELOG.md
+version = "0.2.7" # also update xshell-macros/Cargo.toml and CHANGELOG.md
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/xshell"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
@@ -14,7 +14,7 @@ exclude = [".github/", "bors.toml", "rustfmt.toml", "cbench", "mock_bin/"]
 [workspace]
 
 [dependencies]
-xshell-macros = { version = "=0.2.6", path = "./xshell-macros" }
+xshell-macros = { version = "=0.2.7", path = "./xshell-macros" }
 
 [dev-dependencies]
 anyhow = "1.0.56"

--- a/examples/ci.rs
+++ b/examples/ci.rs
@@ -27,7 +27,7 @@ fn test(sh: &Shell) -> Result<()> {
     // running this, we've already compiled a  bunch of stuff. Originally we tried to `rm -rf
     // .target`, but we also observed weird SIGKILL: 9 errors on mac. Perhaps its our self-removal?
     // Let's scope it only to linux (windows won't work, bc one can not remove oneself there).
-    if cfg!(linux) {
+    if cfg!(unix) {
         sh.remove_path("./target")?;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,7 @@ pub use xshell_macros::__cmd;
 #[macro_export]
 macro_rules! cmd {
     ($sh:expr, $cmd:literal) => {{
-        #[cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)]
+        #[cfg(any())] // Trick rust analyzer into highlighting interpolated bits
         format_args!($cmd);
         let f = |prog| $sh.cmd(prog);
         let cmd: $crate::Cmd = $crate::__cmd!(f $cmd);

--- a/xshell-macros/Cargo.toml
+++ b/xshell-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xshell-macros"
 description = "Private implementation detail of xshell crate"
-version = "0.2.6"
+version = "0.2.7"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/xshell"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]


### PR DESCRIPTION
This PR replace the non-existant `trick_rust_analyzer_into_highlighting_interpolated_bits` cfg in the `cmd!` macro with an always false cfg expression, as to not trigger the upcoming `unexpected_cfgs` lint report in macro.

cc https://github.com/rust-lang/rust/pull/132577
cc @matklad